### PR TITLE
[SRE-2199] Package latest version of Redis Graph into a Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2.8.8
+
+* Package Redis Graph v2.8.8.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Intellection/SRE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM redislabs/redisgraph:2.8.8

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Zappi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# docker-redis-graph
+# RedisGraph
+
+RedisGraph is the first queryable [Property Graph](https://github.com/opencypher/openCypher/blob/master/docs/property-graph-model.adoc) database to use [sparse matrices](https://en.wikipedia.org/wiki/Sparse_matrix) to represent the [adjacency matrix](https://en.wikipedia.org/wiki/Adjacency_matrix) in graphs and [linear algebra](http://faculty.cse.tamu.edu/davis/GraphBLAS.html) to query the graph.
+
+Primary features:
+
+* Adopting the [Property Graph Model](https://github.com/opencypher/openCypher/blob/master/docs/property-graph-model.adoc)
+  * Nodes (vertices) and Relationships (edges) that may have attributes
+  * Nodes that can be labeled
+  * Relationships have a relationship type
+* Graphs represented as sparse adjacency matrices
+* [Cypher](http://www.opencypher.org/) as query language
+  * Cypher queries translated into linear algebra expressions
+
+To see RedisGraph in action, visit [Demos](https://github.com/RedisGraph/RedisGraph/tree/master/demo).
+To read the docs, visit [redisgraph.io](http://redisgraph.io).
+
+See upstream project at [github.com/RedisGraph/RedisGraph](https://github.com/RedisGraph/RedisGraph) for more details.
+
+## Docker
+
+To run the service in Docker use:
+
+```bash
+docker run -p 6379:6379 zappi/redis-graph:<tag>
+```


### PR DESCRIPTION
Title says it all.

### References

* https://github.com/RedisGraph/RedisGraph
* https://hub.docker.com/r/redislabs/redisgraph
* https://hub.docker.com/repository/docker/zappi/redis-graph