### PR TITLE
[SRE-2199] Copy scripts to support Redis Sentinel bootstrapping in Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.8-1
+
+* Add bash scripts to run Redis Sentinel easily in Kubernetes.
+
 ## 2.8.8
 
 * Package Redis Graph v2.8.8.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
 FROM redislabs/redisgraph:2.8.8
+
+COPY --from=zappi/redis:6.2.6 /opt/redis/scripts/ /opt/redis/scripts/


### PR DESCRIPTION
So that we can use [Redis Sentinel](https://redis.io/topics/sentinel) to run a highly available [Redis Graph](https://redis.com/modules/redis-graph/) setup.

### References

* https://github.com/Intellection/docker-redis/pull/1