### PR TITLE
Upgrade RedisGraph to 2.8.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.20
+
+* Bump RedisGraph to v2.8.20
+
 ## 2.8.19
 
 * Bump RedisGraph to v2.8.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM redislabs/redisgraph:2.8.19
+FROM redislabs/redisgraph:2.8.20
 
 COPY --from=zappi/redis:6.2.6 /opt/redis/scripts/ /opt/redis/scripts/


### PR DESCRIPTION
This has been fixed: https://github.com/RedisGraph/RedisGraph/pull/2599, hence the upgrade to `2.8.20`